### PR TITLE
Restore stringification of response bodies

### DIFF
--- a/src/utils/createResponse.js
+++ b/src/utils/createResponse.js
@@ -4,7 +4,7 @@ export default ({ body = {}, statusCode = 200 }) => {
 		headers: {
 			'Access-Control-Allow-Origin': '*', // Required for CORS support to work
 		},
-		body,
+		body: JSON.stringify(body),
 	};
 	return response;
 };


### PR DESCRIPTION
* Bring master in line with develop branch by stringifying body in
  createResponse utility function
* Document service code expects response body to be stringified