### PR TITLE
feat: New release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
 
 jobs:
   lint:
@@ -59,7 +61,7 @@ jobs:
       BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
   update-lambda-code:
-    #if: ${{ github.ref_name == github.event.repository.default_branch }}
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
     uses: dvsa/.github/.github/workflows/update-lambda-function.yaml@v2.2
     needs: [ build-names, build, upload-s3 ]
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  COPY_SOURCE: token/decrypt/master.zip
+  KEY_PATH: token/decrypt
+
+jobs:
+
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.RSP_AWS_ACCOUNT }}:role/GithubActionsRole
+          role-session-name: GithubActionsSession
+          aws-region: ${{ secrets.RSP_AWS_REGION }}
+      - name: Upload to s3
+        run: >
+          aws s3api copy-object
+          --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.COPY_SOURCE }}
+          --key ${{ env.KEY_PATH }}/release-${{ github.ref_name }}.zip
+          --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}

--- a/.github/workflows/update-code.yaml
+++ b/.github/workflows/update-code.yaml
@@ -19,7 +19,7 @@ jobs:
     with:
       environment: ${{ github.event.inputs.environment }}
       lambda_function_name: rsp-nonprod-apis-token-decrypt
-      bucket_key: token/decrypt/${{ needs.build-names.outputs.pretty_branch_name }}.zip
+      bucket_key: token/decrypt/${{ github.event.inputs.zip_archive }}
     permissions:
       id-token: write
     secrets:


### PR DESCRIPTION
## Description

- New workflow to be triggered when release is done through GitHub UI
- Workflow to copy latest default branch build and rename it to release name in S3
- Release tag number prepended to build archive in S3
- Fix for incorrect bucket key in update function code workflow
- Only build branches on push event, don't trigger a build when a new tag is created
- Fix for commented out if check on update code step

Related issue: [RSP-2096](https://dvsa.atlassian.net/browse/RSP-2096)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
