### PR TITLE
feat: Add tagging into release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,8 @@ jobs:
       - name: Upload to s3
         run: >
           aws s3api copy-object
+          --tagging-directive REPLACE
+          --tagging promote=YES
           --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.COPY_SOURCE }}
           --key ${{ env.KEY_PATH }}/release-${{ github.ref_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}


### PR DESCRIPTION
## Description

- In the release action, tag s3 object as it's copied to the release archive
- Tag with promote so replication tasks can pick up the tag and start replication of the new archive


Related issue: [RSP-2114](https://dvsa.atlassian.net/browse/RSP-2114)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
