### PR TITLE
ci: added release-please action to release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,9 @@ jobs:
     needs: [lambdas, release-please]
     permissions:
       id-token: write
+    strategy:
+      matrix:
+        lambdaName: ${{ fromJSON(needs.lambdas.outputs.matrix).lambdas }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -54,5 +57,5 @@ jobs:
           --tagging-directive REPLACE
           --tagging promote=YES
           --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.COPY_SOURCE }}
-          --key ${{ secrets.S3_KEY_PATH }}/release-${{ needs.release-please.outputs.tag_name }}.zip
+          --key ${{ secrets.S3_KEY_PATH }}/${{ matrix.lambdaName }}/release-${{ needs.release-please.outputs.tag_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,31 +1,58 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
 
 env:
-  COPY_SOURCE: token/decrypt/master.zip
-  KEY_PATH: token/decrypt
+  COPY_SOURCE: master.zip
 
 jobs:
-
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: ${{ github.event.repository.name }}
+  lambdas:
+    if: ${{ needs.release-please.outputs.release_created }}
+    needs: release-please
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.json.outputs.MATRIX }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Read in lambdas names from JSON
+        id: json
+        run: |
+          echo "MATRIX=$(jq -c . < ./lambdas.json)" >> $GITHUB_OUTPUT
   promote:
     runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.release_created }}
+    needs: [lambdas, release-please]
     permissions:
       id-token: write
     steps:
-      - name: Configure aws credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: arn:aws:iam::${{ secrets.RSP_AWS_ACCOUNT }}:role/GithubActionsRole
           role-session-name: GithubActionsSession
           aws-region: ${{ secrets.RSP_AWS_REGION }}
-      - name: Upload to s3
+      - name: Upload to S3
         run: >
           aws s3api copy-object
           --tagging-directive REPLACE
           --tagging promote=YES
           --copy-source ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}/${{ env.COPY_SOURCE }}
-          --key ${{ env.KEY_PATH }}/release-${{ github.ref_name }}.zip
+          --key ${{ secrets.S3_KEY_PATH }}/release-${{ needs.release-please.outputs.tag_name }}.zip
           --bucket ${{ secrets.RSP_NONPROD_S3_BUCKET_NAME }}

--- a/lambdas.json
+++ b/lambdas.json
@@ -1,0 +1,6 @@
+{
+    "description": "File containing the names of all the lambda functions in this service. Lambda names are used for building in webpack and deploying from GitHub Actions.",
+    "lambdas": [
+          "decrypt"
+    ]
+}

--- a/lambdas.json
+++ b/lambdas.json
@@ -1,6 +1,6 @@
 {
     "description": "File containing the names of all the lambda functions in this service. Lambda names are used for building in webpack and deploying from GitHub Actions.",
     "lambdas": [
-          "serveExpressApp"
+          "decrypt"
     ]
 }

--- a/lambdas.json
+++ b/lambdas.json
@@ -1,6 +1,6 @@
 {
     "description": "File containing the names of all the lambda functions in this service. Lambda names are used for building in webpack and deploying from GitHub Actions.",
     "lambdas": [
-          "decrypt"
+          "serveExpressApp"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsp-token-decrypt",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "Service to decrypt RSP token",
   "repository": "github/dvsa/rsp-token-service",
   "author": "",


### PR DESCRIPTION

## Description

- Modified workflow to run on pushes to master branch
- Added job to run release-please action
- Modified promote job to require completion of release-please, and only run when release-please outputs a created release (ie when a release PR is merged)
- To make release process consistent across RSP repos, lambdas.json was added (if missing) and S3 key was moved to environment variable, and lambdas step was added to release workflow to map lambdas for promotion.

Related issue: [RSP-2170](https://dvsa.atlassian.net/browse/RSP-2170)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>